### PR TITLE
Fix rightAccessoryButton with image being forced to text

### DIFF
--- a/Code/Views/ATLMessageInputToolbar.m
+++ b/Code/Views/ATLMessageInputToolbar.m
@@ -370,17 +370,12 @@ static CGFloat const ATLButtonHeight = 28.0f;
 
 - (void)configureRightAccessoryButtonState
 {
-    if (self.textInputView.text.length) {
-        [self configureRightAccessoryButtonForText];
+    if (self.displaysRightAccessoryImage) {
+        [self configureRightAccessoryButtonForImage];
         self.rightAccessoryButton.enabled = YES;
     } else {
-        if (self.displaysRightAccessoryImage) {
-            [self configureRightAccessoryButtonForImage];
-            self.rightAccessoryButton.enabled = YES;
-        } else {
-            [self configureRightAccessoryButtonForText];
-            self.rightAccessoryButton.enabled = NO;
-        }
+        [self configureRightAccessoryButtonForText];
+        self.rightAccessoryButton.enabled = NO;
     }
 }
 


### PR DESCRIPTION
It was impossible to show an image in the button when the text is not empty as `configureRightAccessoryButtonForText` was called no matter what.