### PR TITLE
Allow ATLMessageInputToolbar’s UI to be completely customized from IB

### DIFF
--- a/Code/Views/ATLMessageInputToolbar.h
+++ b/Code/Views/ATLMessageInputToolbar.h
@@ -94,12 +94,12 @@ extern NSString *const ATLMessageInputToolbarAccessibilityLabel;
  @abstract The left accessory button for the view. 
  @discussion By default, the button displays a camera icon. If set to `nil` the `textInputView` will expand to the left edge of the toolbar.
  */
-@property (nonatomic) UIButton * _Nullable leftAccessoryButton;
+@property (nonatomic) IBOutlet UIButton *leftAccessoryButton;
  
 /**
  @abstract The right accessory button for the view.
  */
-@property (nonatomic) UIButton *rightAccessoryButton;
+@property (nonatomic) IBOutlet UIButton *rightAccessoryButton;
 
 /**
  @abstract The right accessory button title.
@@ -144,7 +144,7 @@ extern NSString *const ATLMessageInputToolbarAccessibilityLabel;
 /**
  @abstract An automatically resizing message composition field.
  */
-@property (nonatomic) ATLMessageComposeTextView *textInputView;
+@property (nonatomic) IBOutlet ATLMessageComposeTextView *textInputView;
 
 /**
   @abstract The margin on top and bottom of the textInputView.
@@ -170,6 +170,16 @@ extern NSString *const ATLMessageInputToolbarAccessibilityLabel;
  @discussion Any existing media attachments will be removed when the right accessory button is tapped.
  */
 @property (nonatomic, readonly, nullable) NSArray <ATLMediaAttachment*> *mediaAttachments;
+
+/**
+ @abstract The method called when the leftAccessoryButton is tapped.
+ */
+- (IBAction)leftAccessoryButtonTapped:(id)sender;
+
+/**
+ @abstract The method called when the rightAccessoryButton is tapped.
+ */
+- (IBAction)rightAccessoryButtonTapped:(id)sender;
 
 //-------------------
 // Layout Accessories

--- a/Code/Views/ATLMessageInputToolbar.m
+++ b/Code/Views/ATLMessageInputToolbar.m
@@ -32,6 +32,7 @@ NSString *const ATLMessageInputToolbarDidChangeHeightNotification = @"ATLMessage
 @property (nonatomic) CGFloat textViewMaxHeight;
 @property (nonatomic) CGFloat buttonCenterY;
 @property (nonatomic) BOOL firstAppearance;
+@property (nonatomic) BOOL customUI;
 
 @end
 
@@ -106,9 +107,20 @@ static CGFloat const ATLButtonHeight = 28.0f;
     return self;
 }
 
+- (instancetype)initWithCoder:(NSCoder *)coder
+{
+    self = [super initWithCoder:coder];
+    if (self) {
+        self.customUI = YES;
+    }
+    return self;
+}
+
 - (void)layoutSubviews
 {
     [super layoutSubviews];
+    
+    if (self.customUI) return;
     
     if (self.firstAppearance) {
         [self configureRightAccessoryButtonState];
@@ -271,12 +283,12 @@ static CGFloat const ATLButtonHeight = 28.0f;
 
 #pragma mark - Actions
 
-- (void)leftAccessoryButtonTapped
+- (IBAction)leftAccessoryButtonTapped:(id)sender
 {
     [self.inputToolBarDelegate messageInputToolbar:self didTapLeftAccessoryButton:self.leftAccessoryButton];
 }
 
-- (void)rightAccessoryButtonTapped
+- (IBAction)rightAccessoryButtonTapped:(id)sender
 {
     [self acceptAutoCorrectionSuggestion];
     if ([self.inputToolBarDelegate respondsToSelector:@selector(messageInputToolbarDidEndTyping:)]) {
@@ -370,6 +382,8 @@ static CGFloat const ATLButtonHeight = 28.0f;
 
 - (void)configureRightAccessoryButtonState
 {
+    if (self.customUI) return;
+
     if (self.textInputView.text.length) {
         [self configureRightAccessoryButtonForText];
         self.rightAccessoryButton.enabled = YES;


### PR DESCRIPTION
This pull request allows to create a 100% custom toolbar using IB while keeping `ATLMessageInputToolbar` functionality.

* Make `leftAccessoryButton`, `rightAccessoryButton` and `textInputView` IBOutlets.
* Make `leftAccessoryButtonTapped` and `rightAccessoryButtonTapped` IBActions.
* Do not `layoutSubviews` or `configureRightAccessoryButtonState` when view is instantiated from IB.